### PR TITLE
fix: remove promise after resposne

### DIFF
--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -82,6 +82,7 @@ export class RPC<
               } else {
                 promise.reject(new Error(response.error))
               }
+              this.promises.delete(response.id)
             }
           }
           break


### PR DESCRIPTION
To make sure if a response arrives twice the second one will be ignored.