### PR TITLE
refactor: move transport outside of rpc namespace

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,7 @@ import type { Config } from '@jest/types'
 const config: Config.InitialOptions = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
-  setupFiles: ['./test/setup.ts']
+  setupFiles: ['./test/setup.ts'],
 }
 
 export default config

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
+/* istanbul ignore file */
 export * from './transports'
-export { RPC } from './rpc'
+export * from './transport'
+export * from './rpc'

--- a/src/rpc.spec.ts
+++ b/src/rpc.spec.ts
@@ -1,5 +1,6 @@
 import { InMemoryTransport } from './transports'
 import { RPC } from './rpc'
+import { Transport } from './transport'
 
 namespace Test {
   export enum Method {
@@ -30,7 +31,7 @@ class Client extends RPC<
   Test.EventType,
   Test.EventData
 > {
-  constructor(transport: RPC.Transport) {
+  constructor(transport: Transport) {
     super('test', transport)
   }
   async add(a: number, b: number) {
@@ -50,7 +51,7 @@ class Server extends RPC<
   Test.EventType,
   Test.EventData
 > {
-  constructor(transport: RPC.Transport) {
+  constructor(transport: Transport) {
     super('test', transport)
     this.handle('add', async ({ a, b }) => {
       if (isNaN(a) || isNaN(b)) {

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -1,10 +1,10 @@
 import mitt from 'mitt'
 import future, { IFuture } from 'fp-future'
+import { Message, Transport } from './transport'
 
 /**
  * A class to implement RPC server/client or simple event emitters over an abstract transport
  */
-
 
 export class RPC<
   Method extends string = string,
@@ -23,7 +23,7 @@ export class RPC<
 
   constructor(
     public id: string,
-    public transport: RPC.Transport,
+    public transport: Transport,
   ) {
     this.transport.addEventListener('message', this.handler)
   }
@@ -87,7 +87,7 @@ export class RPC<
 
   private isMessage(
     value: any,
-  ): value is RPC.Message<
+  ): value is Message<
     RPC.MessageType,
     RPC.MessagePayload<Method, Params, Result, EventType, EventData>
   > {
@@ -178,7 +178,7 @@ export class RPC<
       EventType,
       EventData
     >[Type],
-  ): RPC.Message<
+  ): Message<
     Type,
     RPC.MessagePayload<Method, Params, Result, EventType, EventData>
   > => ({
@@ -188,46 +188,8 @@ export class RPC<
   })
 }
 
+/* istanbul ignore next line */
 export namespace RPC {
-  export abstract class Transport {
-    abstract send(message: Message): void
-    private events = mitt<Transport.EventData>()
-    emit(type: `${Transport.EventType}`, message: Message) {
-      this.events.emit(type as Transport.EventType, message)
-    }
-    addEventListener(
-      type: `${Transport.EventType}`,
-      handler: Transport.Handler,
-    ) {
-      this.events.on(type as Transport.EventType, handler)
-    }
-    removeEventListener(
-      type: `${Transport.EventType}`,
-      handler: Transport.Handler,
-    ) {
-      this.events.off(type as Transport.EventType, handler)
-    }
-  }
-
-  export namespace Transport {
-    export enum EventType {
-      MESSAGE = 'message',
-    }
-    export type EventData = {
-      [EventType.MESSAGE]: Message
-    }
-    export type Handler = (message: Message) => void
-  }
-
-  export type Message<
-    Type extends string = string,
-    Payload extends Record<Type, any> = Record<Type, any>,
-  > = {
-    id: string
-    type: Type
-    payload: Payload[Type]
-  }
-
   export enum MessageType {
     REQUEST = 'request',
     RESPONSE = 'response',

--- a/src/transport.spec.ts
+++ b/src/transport.spec.ts
@@ -1,0 +1,53 @@
+import { Message, Transport } from './transport'
+
+describe('Transport', () => {
+  const sendMock = jest.fn()
+  const handlerMock = jest.fn()
+
+  const message: Message = {
+    id: 'test',
+    type: 'test',
+    payload: 'test',
+  }
+
+  class TestTransport extends Transport {
+    send(message: Message) {
+      return sendMock(message)
+    }
+  }
+
+  const transport = new TestTransport()
+
+  afterEach(() => {
+    sendMock.mockReset()
+    handlerMock.mockReset()
+  })
+
+  describe('When sending a message throw a transport', () => {
+    it('should send te message', () => {
+      transport.send(message)
+      expect(sendMock).toHaveBeenCalledWith(message)
+    })
+  })
+  describe('When emiting a message from a transport', () => {
+    describe('and there is a handler listening to the message event', () => {
+      beforeAll(() => {
+        transport.addEventListener('message', handlerMock)
+      })
+      afterAll(() => {
+        transport.removeEventListener('message', handlerMock)
+      })
+      it('should call the handler with the message', () => {
+        transport.emit('message', message)
+        expect(handlerMock).toHaveBeenCalledWith(message)
+      })
+      describe('and the listener is removed', () => {
+        it('should NOT call the handler with the message', () => {
+          transport.removeEventListener('message', handlerMock)
+          transport.emit('message', message)
+          expect(handlerMock).not.toHaveBeenCalledWith(message)
+        })
+      })
+    })
+  })
+})

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,0 +1,24 @@
+import mitt from 'mitt'
+
+export type Message<
+  Type extends string = string,
+  Payload extends Record<Type, any> = Record<Type, any>,
+> = {
+  id: string
+  type: Type
+  payload: Payload[Type]
+}
+
+export abstract class Transport {
+  abstract send(message: Message): void
+  private events = mitt<{ message: Message }>()
+  emit(type: 'message', message: Message) {
+    this.events.emit(type, message)
+  }
+  addEventListener(type: 'message', handler: (message: Message) => void) {
+    this.events.on(type, handler)
+  }
+  removeEventListener(type: 'message', handler: (message: Message) => void) {
+    this.events.off(type, handler)
+  }
+}

--- a/src/transports/in-memory.spec.ts
+++ b/src/transports/in-memory.spec.ts
@@ -1,7 +1,7 @@
-import { RPC } from '../rpc'
+import { Message } from '../transport'
 import { InMemoryTransport } from './in-memory'
 
-const message: RPC.Message = { id: 'test', type: 'foo', payload: 'bar' }
+const message: Message = { id: 'test', type: 'foo', payload: 'bar' }
 
 describe('InMemoryTransport', () => {
   let transportA: InMemoryTransport

--- a/src/transports/in-memory.ts
+++ b/src/transports/in-memory.ts
@@ -1,8 +1,8 @@
-import { RPC } from '../rpc'
+import { Message, Transport } from '../transport'
 
-export class InMemoryTransport extends RPC.Transport {
-  private others = new Set<RPC.Transport>()
-  send(message: RPC.Message) {
+export class InMemoryTransport extends Transport {
+  private others = new Set<Transport>()
+  send(message: Message) {
     for (const transport of this.others) {
       transport.emit('message', message)
     }

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -1,2 +1,3 @@
+/* istanbul ignore file */
 export { InMemoryTransport } from './in-memory'
 export { MessageTransport } from './message'

--- a/src/transports/message.spec.ts
+++ b/src/transports/message.spec.ts
@@ -1,20 +1,26 @@
 import mitt from 'mitt'
-import { RPC } from '../rpc'
 import { MessageTransport } from './message'
+import { Message } from '../transport'
 
 const events = mitt()
 const send = (message: any) => events.emit('message', { data: message })
 
 const source = {
-  addEventListener: jest.fn().mockImplementation((type, hanlder) => events.on(type, hanlder)),
-  removeEventListener: jest.fn()
+  addEventListener: jest
+    .fn()
+    .mockImplementation((type, hanlder) => events.on(type, hanlder)),
+  removeEventListener: jest.fn(),
 }
 
 const target = {
-  postMessage: jest.fn()
+  postMessage: jest.fn(),
 }
 
-const message: RPC.Message = { id: 'test', type: 'foo', payload: { bar: 'baz' } }
+const message: Message = {
+  id: 'test',
+  type: 'foo',
+  payload: { bar: 'baz' },
+}
 
 describe('MessageTransport', () => {
   let transport: MessageTransport
@@ -66,12 +72,12 @@ describe('MessageTransport', () => {
       transport.send(message)
       expect(target.postMessage).toHaveBeenCalledWith(message, '*')
     })
-    it("should handle messages from the source and emit them", () => {
-      const handler = jest.fn();
-      transport.addEventListener("message", handler);
-      send(message);
-      expect(handler).toHaveBeenCalledWith(message);
-    });
+    it('should handle messages from the source and emit them', () => {
+      const handler = jest.fn()
+      transport.addEventListener('message', handler)
+      send(message)
+      expect(handler).toHaveBeenCalledWith(message)
+    })
   })
 
   describe('When disposing the transport', () => {

--- a/src/transports/message.ts
+++ b/src/transports/message.ts
@@ -1,19 +1,29 @@
-import { RPC } from '../rpc'
+import { Transport } from '../transport'
 
 type Source = {
-  addEventListener: (type: 'message', handler: (event: MessageEvent) => void) => void
-  removeEventListener: (type: 'message', handler: (event: MessageEvent) => void) => void
+  addEventListener: (
+    type: 'message',
+    handler: (event: MessageEvent) => void,
+  ) => void
+  removeEventListener: (
+    type: 'message',
+    handler: (event: MessageEvent) => void,
+  ) => void
 }
 
 type Target = {
   postMessage: (message: any, origin: string) => void
 }
 
-export class MessageTransport extends RPC.Transport {
+export class MessageTransport extends Transport {
   private ready = false
   private queue: any[] = []
 
-  constructor(public source: Source, public target: Target, public origin: string = '*') {
+  constructor(
+    public source: Source,
+    public target: Target,
+    public origin: string = '*',
+  ) {
     super()
     // bind handler
     this.source.addEventListener('message', this.handler)


### PR DESCRIPTION
Move `Transport` outside of `RPC` namespace