### PR TITLE
fix: move queue logic from Transport to RPC

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.0.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest: Current File",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["${fileBasenameNoExtension}", "--config", "jest.config.ts"],
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/src/rpc.spec.ts
+++ b/src/rpc.spec.ts
@@ -73,55 +73,59 @@ const server = new Server(transportB)
 
 describe('RPC', () => {
   describe('When requesting a method from the client', () => {
-    describe('and the server response is successful', () => {
-      it("should resolve the client request to the server's response", async () => {
-        await expect(client.add(1, 2)).resolves.toBe(3)
+    describe('When the RPC is ready', () => {
+      describe('and the server response is successful', () => {
+        it("should resolve the client request to the server's response", async () => {
+          await expect(client.add(1, 2)).resolves.toBe(3)
+        })
+      })
+      describe('and the server response is NOT successful', () => {
+        it("should reject the client request with the server's error message", async () => {
+          await expect(client.add(1, NaN)).rejects.toThrow(/NaN/)
+        })
+      })
+      describe('and the server has not implemented the method', () => {
+        it('should reject the client request with an unimplemented method error', async () => {
+          await expect(client.unimplemented()).rejects.toThrow(
+            /not implemented/,
+          )
+        })
       })
     })
-    describe('and the server response is NOT successful', () => {
-      it("should reject the client request with the server's error message", async () => {
-        await expect(client.add(1, NaN)).rejects.toThrow(/NaN/)
-      })
-    })
-    describe('and the server has not implemented the method', () => {
-      it('should reject the client request with an unimplemented method error', async () => {
-        await expect(client.unimplemented()).rejects.toThrow(/not implemented/)
-      })
-    })
-  })
-  describe('When emitting an event on the server', () => {
-    it('should be handled by the client', () => {
-      const handler = jest.fn()
-      client.on('foo', handler)
-      server.emit('foo', { bar: 'baz' })
-      expect(handler).toHaveBeenCalledTimes(1)
-      expect(handler).toHaveBeenCalledWith({ bar: 'baz' })
-    })
-  })
-  describe('When emitting an event on the client', () => {
-    it('should be handled by the server', () => {
-      const handler = jest.fn()
-      server.on('foo', handler)
-      client.emit('foo', { bar: 'baz' })
-      expect(handler).toHaveBeenCalledTimes(1)
-      expect(handler).toHaveBeenCalledWith({ bar: 'baz' })
-    })
-    describe('and the handler has been unbound', () => {
-      it('should not be called', () => {
+    describe('When emitting an event on the server', () => {
+      it('should be handled by the client', () => {
         const handler = jest.fn()
         client.on('foo', handler)
-        client.off('foo', handler)
         server.emit('foo', { bar: 'baz' })
-        expect(handler).not.toHaveBeenCalled()
+        expect(handler).toHaveBeenCalledTimes(1)
+        expect(handler).toHaveBeenCalledWith({ bar: 'baz' })
       })
     })
-    describe('and the rpc has been disposed', () => {
-      it('should not handle the event', () => {
+    describe('When emitting an event on the client', () => {
+      it('should be handled by the server', () => {
         const handler = jest.fn()
-        client.on('foo', handler)
-        client.dispose()
-        server.emit('foo', { bar: 'baz' })
-        expect(handler).not.toHaveBeenCalled()
+        server.on('foo', handler)
+        client.emit('foo', { bar: 'baz' })
+        expect(handler).toHaveBeenCalledTimes(1)
+        expect(handler).toHaveBeenCalledWith({ bar: 'baz' })
+      })
+      describe('and the handler has been unbound', () => {
+        it('should not be called', () => {
+          const handler = jest.fn()
+          client.on('foo', handler)
+          client.off('foo', handler)
+          server.emit('foo', { bar: 'baz' })
+          expect(handler).not.toHaveBeenCalled()
+        })
+      })
+      describe('and the rpc has been disposed', () => {
+        it('should not handle the event', () => {
+          const handler = jest.fn()
+          client.on('foo', handler)
+          client.dispose()
+          server.emit('foo', { bar: 'baz' })
+          expect(handler).not.toHaveBeenCalled()
+        })
       })
     })
   })

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -106,6 +106,11 @@ export class RPC<
               this.send(message)
             }
 
+            // wait for next frame, this allow the contructor on the other end to finish setting up hanlders if necessary
+            const frame = future<unknown>()
+            requestAnimationFrame(frame.resolve)
+            await frame
+
             // flush the queue
             while (this.queue.length > 0) {
               const message = this.queue.shift()!

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -30,7 +30,12 @@ export class RPC<
     public id: string,
     public transport: Transport,
   ) {
+    // bind transport
     this.transport.addEventListener('message', this.handler)
+
+    // init connection
+    const message = this.createMessage('connection', { type: 'ping' })
+    this.transport.send(message)
   }
 
   private handler = async (message: any) => {
@@ -160,11 +165,7 @@ export class RPC<
   }
 
   private isConnection(value: any): value is RPC.Connection {
-    return (
-      value &&
-      (value.type === 'ping' || value.type === 'pong') &&
-      typeof value.id === 'number'
-    )
+    return value && (value.type === 'ping' || value.type === 'pong')
   }
 
   on<T extends EventType>(type: `${T}`, handler: (data: EventData[T]) => void) {

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -95,6 +95,7 @@ export class RPC<
           if (this.isConnection(message.payload)) {
             const connection = message.payload
 
+            // set as connected
             if (!this.ready) {
               this.ready = true
             }

--- a/src/transports/message.spec.ts
+++ b/src/transports/message.spec.ts
@@ -42,42 +42,15 @@ describe('MessageTransport', () => {
     })
   })
 
-  describe('When the transport is not ready', () => {
-    it('the messages sent through it should be queued', () => {
-      transport.send(message)
-      expect(target.postMessage).not.toHaveBeenCalledWith(message, '*')
-    })
-    describe('and a ping message arrives', () => {
-      it('should flush queued messages and send a pong message', () => {
-        transport.send(message)
-        send({ type: 'ping' })
-        expect(target.postMessage).toHaveBeenCalledWith({ type: 'pong' }, '*')
-        expect(target.postMessage).toHaveBeenCalledWith(message, '*')
-      })
-    })
-    describe('and a pong message arrives', () => {
-      it('should flush queued messages', () => {
-        transport.send(message)
-        send({ type: 'pong' })
-        expect(target.postMessage).toHaveBeenCalledWith(message, '*')
-      })
-    })
+  it('should send post messages to the target', () => {
+    transport.send(message)
+    expect(target.postMessage).toHaveBeenCalledWith(message, '*')
   })
-
-  describe('When the transport is ready', () => {
-    beforeEach(() => {
-      send({ type: 'pong' })
-    })
-    it('should send post messages to the target', () => {
-      transport.send(message)
-      expect(target.postMessage).toHaveBeenCalledWith(message, '*')
-    })
-    it('should handle messages from the source and emit them', () => {
-      const handler = jest.fn()
-      transport.addEventListener('message', handler)
-      send(message)
-      expect(handler).toHaveBeenCalledWith(message)
-    })
+  it('should handle messages from the source and emit them', () => {
+    const handler = jest.fn()
+    transport.addEventListener('message', handler)
+    send(message)
+    expect(handler).toHaveBeenCalledWith(message)
   })
 
   describe('When disposing the transport', () => {

--- a/src/transports/message.spec.ts
+++ b/src/transports/message.spec.ts
@@ -36,12 +36,6 @@ describe('MessageTransport', () => {
     target.postMessage.mockClear()
   })
 
-  describe('When creating a MessageTransport', () => {
-    it('should send a ping message to the target', () => {
-      expect(target.postMessage).toHaveBeenCalledWith({ type: 'ping' }, '*')
-    })
-  })
-
   it('should send post messages to the target', () => {
     transport.send(message)
     expect(target.postMessage).toHaveBeenCalledWith(message, '*')

--- a/src/transports/message.ts
+++ b/src/transports/message.ts
@@ -16,9 +16,6 @@ type Target = {
 }
 
 export class MessageTransport extends Transport {
-  private ready = false
-  private queue: any[] = []
-
   constructor(
     public source: Source,
     public target: Target,
@@ -33,39 +30,12 @@ export class MessageTransport extends Transport {
 
   private handler = (event: MessageEvent) => {
     if (event.data) {
-      // special messages to establish communication
-      if (event.data.type === 'ping' || event.data.type === 'pong') {
-        // set as ready if was not yet
-        if (!this.ready) {
-          this.ready = true
-        }
-
-        // answer ping with pong
-        if (event.data.type === 'ping') {
-          this.target.postMessage({ type: 'pong' }, this.origin)
-        }
-
-        // flush the queue
-        while (this.queue.length > 0) {
-          const message = this.queue.shift()
-          this.send(message)
-        }
-
-        // send all other events to the handler (if any)
-      } else {
-        this.emit('message', event.data)
-      }
+      this.emit('message', event.data)
     }
   }
 
   send(message: any) {
-    // if not ready enqueue message
-    if (!this.ready) {
-      this.queue.push(message)
-    } else {
-      // otherwise send it
-      this.target.postMessage(message, this.origin)
-    }
+    this.target.postMessage(message, this.origin)
   }
 
   dispose() {

--- a/src/transports/message.ts
+++ b/src/transports/message.ts
@@ -22,10 +22,7 @@ export class MessageTransport extends Transport {
     public origin: string = '*',
   ) {
     super()
-    // bind handler
     this.source.addEventListener('message', this.handler)
-    // send ping
-    this.target.postMessage({ type: 'ping' }, this.origin)
   }
 
   private handler = (event: MessageEvent) => {


### PR DESCRIPTION
This fixes issues when many clients and/or servers reuse the same transport. The issue before was that the Transport used to wait for the other end to be online, which worked when the Transport and the Client/Server were created at the same time, but when reusing an already connected Transport, a message sent by a Client would not be queued, and sometimes the Server on the other end would not be online yet. So now each Client enqueues the messages until the Server on the other end is ready, instead of being the Transport.